### PR TITLE
Fix error code 309 - invalid list issue

### DIFF
--- a/src/Bronto/Api/Contact/Row.php
+++ b/src/Bronto/Api/Contact/Row.php
@@ -305,6 +305,7 @@ class Bronto_Api_Contact_Row extends Bronto_Api_Row implements Bronto_Api_Delive
                     break;
                 }
             }
+            $this->_data['listIds'] = array_values($this->_data['listIds']);
         }
 
         $this->_modifiedFields['listIds'] = true;


### PR DESCRIPTION
When attempting to use the `removeFromList()` method on a `Bronto_Api_Contact_Row` object I kept receiving 309 invalid list error code back from the API. Upon investigation, I tracked it down to the implementation strategy of the removeFromList method simply unsetting the array value for lists a contact is a member of. When the array is passed to the API, apparently a missing numerical index value causes issues. Reindexing the array for lists fixed the issue in my testing.